### PR TITLE
fix tuling api userid invalid

### DIFF
--- a/example/Handlers/Type/TextType.php
+++ b/example/Handlers/Type/TextType.php
@@ -55,7 +55,7 @@ class TextType
             $result = vbot('http')->post('http://www.tuling123.com/openapi/api', [
                 'key'    => '9c598b601d8e47acafd81f07770d4bba',
                 'info'   => $content,
-                'userid' => $id,
+                'userid' => md5($id),
             ], true);
 
             return isset($result['url']) ? $result['text'].$result['url'] : $result['text'];


### PR DESCRIPTION
> userid	上下文 支持0-9，a-z,A-Z组合，不能包含特殊字符 [图灵API DOC](http://www.tuling123.com/help/h_cent_webapi.jhtml?nav=doc)

上下文标识 `userid` 格式应为 `alpha_num ` 且在32位内。

