### PR TITLE
允许从配置文件注入session值

### DIFF
--- a/src/Foundation/Kernel.php
+++ b/src/Foundation/Kernel.php
@@ -56,9 +56,12 @@ class Kernel
 
     private function prepareSession()
     {
-        $session = new Session($this->vbot);
-
-        $sessionKey = $session->currentSession();
+        if(empty($this->vbot->config['session'])){
+            $session = new Session($this->vbot);
+            $sessionKey = $session->currentSession();
+        }else{
+            $sessionKey = $this->vbot->config['session'];
+        }
 
         $this->vbot->config['session'] = $sessionKey;
         $this->vbot->config['session_key'] = 'session.'.$sessionKey;


### PR DESCRIPTION
如果用多进程管理vbot，从控制台获取session行不通，增加从配置文件拿，便于扩展