### PR TITLE
处理登录的1203错误码

### DIFF
--- a/src/Core/Server.php
+++ b/src/Core/Server.php
@@ -190,7 +190,11 @@ class Server
         $content = $this->vbot->http->get($this->vbot->config['server.uri.redirect']);
 
         $data = (array) simplexml_load_string($content, 'SimpleXMLElement', LIBXML_NOCDATA);
-
+        
+        if (isset($data['ret']) && $data['ret'] == 1203) {
+            throw new LoginFailedException($data['message']);
+        }
+        
         $this->vbot->config['server.skey'] = $data['skey'];
         $this->vbot->config['server.sid'] = $data['wxsid'];
         $this->vbot->config['server.uin'] = $data['wxuin'];


### PR DESCRIPTION
处理登录的`1203`错误码

```
为了你的帐号安全，此微信号不能登录网页微信。你可以使用Windows微信或Mac微信在电脑端登录。Windows微信下载地址：https://pc.weixin.qq.com  Mac微信下载地址：https://mac.weixin.qq.com
```